### PR TITLE
Fixed fatal error in interface procesing

### DIFF
--- a/php-initialized.inc.php
+++ b/php-initialized.inc.php
@@ -255,6 +255,7 @@ function check_variables($filename, $initialized = array(), $function = "", $cla
 			while ($tokens[$i+1] !== '}') {
 				$i++;
 			}
+			$i++;
 
 		// halt_compiler
 		} elseif ($token[0] === T_HALT_COMPILER) {


### PR DESCRIPTION
Fixed fatal error in case of testing file with include of file with only interface definition ending by } token. Call check_variables for include returned int insteead of array with defined variables.
